### PR TITLE
Retrieve and save documents locally from fineract using Http calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.documents
 
 ### STS ###
 .apt_generated

--- a/src/main/java/org/mifos/loanrisk/common/EventMapper.java
+++ b/src/main/java/org/mifos/loanrisk/common/EventMapper.java
@@ -33,7 +33,21 @@ public class EventMapper {
         LocalDateTime ts = LocalDateTime.parse(dto.getCreatedAt(), DateTimeFormatter.ISO_DATE_TIME);
         return new EventMessage(dto.getId(), dto.getType(), dto.getCategory(), dto.getDataschema(), dto.getTenantId(), ts,
                 byteBufferConvertor.convert(dto.getData()), // keep raw bytes
-                dto.getBusinessDate());
+                dto.getBusinessDate(), Boolean.FALSE);
+    }
+
+    public EventEnvelope toEnvelope(EventMessage msg) throws JsonProcessingException, ClassNotFoundException, InvocationTargetException,
+            NoSuchMethodException, IllegalAccessException {
+        return new EventEnvelope(msg.getEventId(), EventCategory.valueOf(msg.getCategory()), msg.getType(), om.readTree(convertMsg(msg)),
+                msg.getTenantId(), msg.getCreatedAt(), msg.getBusinessDate());
+    }
+
+    private String convertMsg(EventMessage msg)
+            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Class<?> payloadClazz = Class.forName(msg.getSchema());
+        Method fromByteBuffer = payloadClazz.getMethod("fromByteBuffer", ByteBuffer.class);
+        Object payload = fromByteBuffer.invoke(null, ByteBuffer.wrap(msg.getPayload()));
+        return payload.toString();
     }
 
     private String convertMsg(MessageV1 msg)

--- a/src/main/java/org/mifos/loanrisk/config/ReactiveTransactionConfig.java
+++ b/src/main/java/org/mifos/loanrisk/config/ReactiveTransactionConfig.java
@@ -1,0 +1,22 @@
+package org.mifos.loanrisk.config;
+
+import io.r2dbc.spi.ConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.r2dbc.connection.R2dbcTransactionManager;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+@Configuration
+public class ReactiveTransactionConfig {
+
+    @Bean
+    public ReactiveTransactionManager transactionManager(ConnectionFactory factory) {
+        return new R2dbcTransactionManager(factory);
+    }
+
+    @Bean
+    public TransactionalOperator transactionalOperator(ReactiveTransactionManager tm) {
+        return TransactionalOperator.create(tm);
+    }
+}

--- a/src/main/java/org/mifos/loanrisk/document/config/WebClientConfig.java
+++ b/src/main/java/org/mifos/loanrisk/document/config/WebClientConfig.java
@@ -1,0 +1,59 @@
+package org.mifos.loanrisk.document.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import java.time.Duration;
+import javax.net.ssl.SSLException;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+@EnableConfigurationProperties(WebClientConfig.FineractProps.class)
+public class WebClientConfig {
+
+    @Bean
+    public WebClient fineractWebClient(FineractProps p) throws SSLException {
+        HttpClient http = HttpClient.create().option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) p.getConnectTimeout().toMillis())
+                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler((int) p.getReadTimeout().toSeconds())));
+
+        if (p.getSsl().isTrustAll()) {
+            SslContext ssl = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+            http = http.secure(spec -> spec.sslContext(ssl));
+        }
+
+        return WebClient.builder().baseUrl(p.getBaseUrl()).defaultHeader("Fineract-Platform-TenantId", p.getTenantId())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeaders(h -> h.setBasicAuth(p.getUsername(), p.getPassword())).clientConnector(new ReactorClientHttpConnector(http))
+                .build();
+    }
+
+    @Data
+    @ConfigurationProperties(prefix = "fineract")
+    public static class FineractProps {
+
+        private String baseUrl;
+        private String tenantId;
+        private String username;
+        private String password;
+        private Duration connectTimeout = Duration.ofSeconds(5);
+        private Duration readTimeout = Duration.ofSeconds(10);
+        private Ssl ssl = new Ssl();
+
+        @Data
+        public static class Ssl {
+
+            private boolean trustAll = false;
+        }
+    }
+}

--- a/src/main/java/org/mifos/loanrisk/document/domain/DocumentMeta.java
+++ b/src/main/java/org/mifos/loanrisk/document/domain/DocumentMeta.java
@@ -1,0 +1,37 @@
+package org.mifos.loanrisk.document.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("document_meta")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DocumentMeta {
+
+    @Id
+    private Long id;
+
+    @Column("loan_id")
+    private Long loanId;
+
+    @Column("document_id")
+    private Long documentId;
+
+    @Column("object_key")
+    private String objectKey;
+
+    @Column("mime_type")
+    private String mimeType;
+
+    @Column("status")
+    private DocumentStatus status;
+
+    @Column("created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/mifos/loanrisk/document/domain/DocumentStatus.java
+++ b/src/main/java/org/mifos/loanrisk/document/domain/DocumentStatus.java
@@ -1,0 +1,7 @@
+package org.mifos.loanrisk.document.domain;
+
+public enum DocumentStatus {
+    NEW,
+    PROCESSED,
+    FAILED
+}

--- a/src/main/java/org/mifos/loanrisk/document/domain/DocumentStatus.java
+++ b/src/main/java/org/mifos/loanrisk/document/domain/DocumentStatus.java
@@ -1,7 +1,5 @@
 package org.mifos.loanrisk.document.domain;
 
 public enum DocumentStatus {
-    NEW,
-    PROCESSED,
-    FAILED
+    NEW, PROCESSED, FAILED
 }

--- a/src/main/java/org/mifos/loanrisk/document/handler/DocumentCreatedHandler.java
+++ b/src/main/java/org/mifos/loanrisk/document/handler/DocumentCreatedHandler.java
@@ -9,6 +9,7 @@ import org.apache.fineract.avro.document.v1.DocumentDataV1;
 import org.mifos.loanrisk.document.common.DocumentEventType;
 import org.mifos.loanrisk.document.common.Handles;
 import org.mifos.loanrisk.service.AggregatorService;
+import org.mifos.loanrisk.document.service.fetch.DocumentFetchService;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,12 +19,16 @@ import org.springframework.stereotype.Component;
 public class DocumentCreatedHandler implements DocumentMessageHandler {
 
     private final AggregatorService aggregatorService;
+    private final DocumentFetchService documentFetchService;
     private final ObjectMapper mapper;
 
     @Override
     public void handle(JsonNode payload) throws JsonProcessingException {
         DocumentDataV1 documentData = mapper.treeToValue(payload, DocumentDataV1.class);
-        aggregatorService.onDocumentCreated(documentData).doOnError(ex -> log.error("DocumentCreated flow failed", ex)).subscribe();
+        aggregatorService.onDocumentCreated(documentData)
+                .then(documentFetchService.fetch(documentData.getParentEntityType(),
+                        documentData.getParentEntityId(), documentData.getId()))
+                .doOnError(ex -> log.error("DocumentCreated flow failed", ex)).subscribe();
 
     }
 }

--- a/src/main/java/org/mifos/loanrisk/document/handler/DocumentCreatedHandler.java
+++ b/src/main/java/org/mifos/loanrisk/document/handler/DocumentCreatedHandler.java
@@ -8,8 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.avro.document.v1.DocumentDataV1;
 import org.mifos.loanrisk.document.common.DocumentEventType;
 import org.mifos.loanrisk.document.common.Handles;
-import org.mifos.loanrisk.service.AggregatorService;
 import org.mifos.loanrisk.document.service.fetch.DocumentFetchService;
+import org.mifos.loanrisk.service.AggregatorService;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,8 +25,8 @@ public class DocumentCreatedHandler implements DocumentMessageHandler {
     @Override
     public void handle(JsonNode payload) throws JsonProcessingException {
         DocumentDataV1 documentData = mapper.treeToValue(payload, DocumentDataV1.class);
-        aggregatorService.onDocumentCreated(documentData)
-                .then(documentFetchService.fetch(documentData.getParentEntityType(),
+        aggregatorService
+                .onDocumentCreated(documentData).then(documentFetchService.fetch(documentData.getParentEntityType(),
                         documentData.getParentEntityId(), documentData.getId()))
                 .doOnError(ex -> log.error("DocumentCreated flow failed", ex)).subscribe();
 

--- a/src/main/java/org/mifos/loanrisk/document/repository/DocumentMetaRepository.java
+++ b/src/main/java/org/mifos/loanrisk/document/repository/DocumentMetaRepository.java
@@ -1,0 +1,10 @@
+package org.mifos.loanrisk.document.repository;
+
+import org.mifos.loanrisk.document.domain.DocumentMeta;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Mono;
+
+public interface DocumentMetaRepository extends R2dbcRepository<DocumentMeta, Long> {
+
+    Mono<DocumentMeta> findByDocumentId(Long documentId);
+}

--- a/src/main/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchService.java
+++ b/src/main/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchService.java
@@ -1,0 +1,45 @@
+package org.mifos.loanrisk.document.service.fetch;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mifos.loanrisk.document.domain.DocumentMeta;
+import org.mifos.loanrisk.document.domain.DocumentStatus;
+import org.mifos.loanrisk.document.repository.DocumentMetaRepository;
+import org.mifos.loanrisk.document.storage.ObjectStorageClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DocumentFetchService {
+
+    private final WebClient fineractClient;
+    private final ObjectStorageClient storageClient;
+    private final DocumentMetaRepository repository;
+    private final TransactionalOperator txOperator;
+
+    public Mono<DocumentMeta> fetch(String entityType, Long entityId, Long documentId) {
+        String path = "/api/v1/%s/%d/documents/%d/attachment".formatted(entityType, entityId, documentId);
+        return fineractClient.get().uri(path).retrieve().toEntity(byte[].class)
+                .flatMap(resp -> {
+                    String mime = resp.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+                    String key = "%s-%d".formatted(entityType, documentId);
+                    DocumentMeta meta = new DocumentMeta(null, entityId, documentId, key, mime,
+                            DocumentStatus.NEW, LocalDateTime.now());
+                    return storageClient.put(resp.getBody(), key)
+                            .then(repository.save(meta))
+                            .as(txOperator::transactional);
+                });
+    }
+
+    private Mono<Void> persistDocument(DocumentMeta meta) {
+        return repository.save(meta)
+                .doOnSuccess(saved -> log.info("Document metadata saved: {}", saved))
+                .then();
+    }
+}

--- a/src/main/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchService.java
+++ b/src/main/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchService.java
@@ -25,21 +25,15 @@ public class DocumentFetchService {
 
     public Mono<DocumentMeta> fetch(String entityType, Long entityId, Long documentId) {
         String path = "/%s/%d/documents/%d/attachment".formatted(entityType, entityId, documentId);
-        return fineractClient.get().uri(path).retrieve().toEntity(byte[].class)
-                .flatMap(resp -> {
-                    String mime = resp.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
-                    String key = "%s-%d".formatted(entityType, documentId);
-                    DocumentMeta meta = new DocumentMeta(null, entityId, documentId, key, mime,
-                            DocumentStatus.NEW, LocalDateTime.now());
-                    return storageClient.put(resp.getBody(), key)
-                            .then(repository.save(meta))
-                            .as(txOperator::transactional);
-                });
+        return fineractClient.get().uri(path).retrieve().toEntity(byte[].class).flatMap(resp -> {
+            String mime = resp.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+            String key = "%s-%d".formatted(entityType, documentId);
+            DocumentMeta meta = new DocumentMeta(null, entityId, documentId, key, mime, DocumentStatus.NEW, LocalDateTime.now());
+            return storageClient.put(resp.getBody(), key).then(repository.save(meta)).as(txOperator::transactional);
+        });
     }
 
     private Mono<Void> persistDocument(DocumentMeta meta) {
-        return repository.save(meta)
-                .doOnSuccess(saved -> log.info("Document metadata saved: {}", saved))
-                .then();
+        return repository.save(meta).doOnSuccess(saved -> log.info("Document metadata saved: {}", saved)).then();
     }
 }

--- a/src/main/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchService.java
+++ b/src/main/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchService.java
@@ -24,7 +24,7 @@ public class DocumentFetchService {
     private final TransactionalOperator txOperator;
 
     public Mono<DocumentMeta> fetch(String entityType, Long entityId, Long documentId) {
-        String path = "/api/v1/%s/%d/documents/%d/attachment".formatted(entityType, entityId, documentId);
+        String path = "/%s/%d/documents/%d/attachment".formatted(entityType, entityId, documentId);
         return fineractClient.get().uri(path).retrieve().toEntity(byte[].class)
                 .flatMap(resp -> {
                     String mime = resp.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);

--- a/src/main/java/org/mifos/loanrisk/document/storage/LocalObjectStorageClient.java
+++ b/src/main/java/org/mifos/loanrisk/document/storage/LocalObjectStorageClient.java
@@ -1,0 +1,42 @@
+package org.mifos.loanrisk.document.storage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LocalObjectStorageClient implements ObjectStorageClient {
+
+    @Value("${app.document.storage.path:documents}")
+    private String basePath;
+
+    private Path path(String key) {
+        return Path.of(basePath, key);
+    }
+
+    @Override
+    public Mono<Void> put(byte[] data, String key) {
+        return Mono.fromRunnable(() -> {
+            try {
+                Files.createDirectories(Path.of(basePath));
+                Files.write(path(key), data);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to store document", e);
+            }
+        }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+
+    @Override
+    public Mono<byte[]> get(String key) {
+        return Mono.fromCallable(() -> Files.readAllBytes(path(key)))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+}

--- a/src/main/java/org/mifos/loanrisk/document/storage/LocalObjectStorageClient.java
+++ b/src/main/java/org/mifos/loanrisk/document/storage/LocalObjectStorageClient.java
@@ -36,7 +36,6 @@ public class LocalObjectStorageClient implements ObjectStorageClient {
 
     @Override
     public Mono<byte[]> get(String key) {
-        return Mono.fromCallable(() -> Files.readAllBytes(path(key)))
-                .subscribeOn(Schedulers.boundedElastic());
+        return Mono.fromCallable(() -> Files.readAllBytes(path(key))).subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/src/main/java/org/mifos/loanrisk/document/storage/LocalObjectStorageClient.java
+++ b/src/main/java/org/mifos/loanrisk/document/storage/LocalObjectStorageClient.java
@@ -15,7 +15,7 @@ import reactor.core.scheduler.Schedulers;
 @Slf4j
 public class LocalObjectStorageClient implements ObjectStorageClient {
 
-    @Value("${app.document.storage.path:documents}")
+    @Value("${app.document.storage.path:.documents}")
     private String basePath;
 
     private Path path(String key) {

--- a/src/main/java/org/mifos/loanrisk/document/storage/ObjectStorageClient.java
+++ b/src/main/java/org/mifos/loanrisk/document/storage/ObjectStorageClient.java
@@ -1,0 +1,10 @@
+package org.mifos.loanrisk.document.storage;
+
+import reactor.core.publisher.Mono;
+
+public interface ObjectStorageClient {
+
+    Mono<Void> put(byte[] data, String key);
+
+    Mono<byte[]> get(String key);
+}

--- a/src/main/java/org/mifos/loanrisk/loan/handler/LoanCreatedHandler.java
+++ b/src/main/java/org/mifos/loanrisk/loan/handler/LoanCreatedHandler.java
@@ -13,6 +13,7 @@ import org.mifos.loanrisk.loan.common.LoanEventType;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -24,12 +25,13 @@ public class LoanCreatedHandler implements LoanMessageHandler {
     private final AggregatorService service;
     private final LoanSnapshotRepository snapshotRepo;
     private final ObjectMapper mapper;
+    private final TransactionalOperator txOperator;
 
     @Override
     public void handle(JsonNode payload) throws JsonProcessingException {
         LoanAccountDataV1 dto = mapper.treeToValue(payload, LoanAccountDataV1.class);
         LoanSnapshot snap = snapshot(dto, payload);
-        Mono.when(service.onLoanCreated(dto), saveSnapshotIfAbsent(dto.getId(), snap))
+        Mono.when(service.onLoanCreated(dto), saveSnapshotIfAbsent(dto.getId(), snap)).as(txOperator::transactional)
                 .doOnError(ex -> log.error("LoanCreated flow failed", ex)).subscribe();
     }
 

--- a/src/main/java/org/mifos/loanrisk/loan/handler/LoanRejectedHandler.java
+++ b/src/main/java/org/mifos/loanrisk/loan/handler/LoanRejectedHandler.java
@@ -11,6 +11,7 @@ import org.mifos.loanrisk.loan.common.LoanEventType;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -22,12 +23,14 @@ public class LoanRejectedHandler implements LoanMessageHandler {
     private final AggregatorService aggregatorService;
     private final LoanSnapshotRepository snapshotRepo;
     private final ObjectMapper mapper;
+    private final TransactionalOperator txOperator;
 
     @Override
     public void handle(JsonNode payload) throws JsonProcessingException {
         LoanAccountDataV1 dto = mapper.treeToValue(payload, LoanAccountDataV1.class);
         Mono.when(aggregatorService.onLoanRejected(dto),
                 snapshotRepo.deleteByLoanId(dto.getId()).doOnSuccess(v -> log.info("Snapshot deleted loan={}", dto.getId())))
-                .doOnError(ex -> log.error("LoanWithdrawn flow failed for loan {}", dto.getId(), ex)).subscribe();
+                .as(txOperator::transactional).doOnError(ex -> log.error("LoanWithdrawn flow failed for loan {}", dto.getId(), ex))
+                .subscribe();
     }
 }

--- a/src/main/java/org/mifos/loanrisk/loan/handler/LoanUpdatedHandler.java
+++ b/src/main/java/org/mifos/loanrisk/loan/handler/LoanUpdatedHandler.java
@@ -13,6 +13,7 @@ import org.mifos.loanrisk.loan.common.LoanEventType;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -24,12 +25,13 @@ public class LoanUpdatedHandler implements LoanMessageHandler {
     private final AggregatorService aggregatorService;
     private final LoanSnapshotRepository snapshotRepo;
     private final ObjectMapper mapper;
+    private final TransactionalOperator txOperator;
 
     @Override
     public void handle(JsonNode payload) throws JsonProcessingException {
         LoanAccountDataV1 dto = mapper.treeToValue(payload, LoanAccountDataV1.class);
         String jsonText = mapper.writeValueAsString(payload);
-        Mono.when(updateAggregator(dto), updateExistingSnapshot(dto.getId(), jsonText))
+        Mono.when(updateAggregator(dto), updateExistingSnapshot(dto.getId(), jsonText)).as(txOperator::transactional)
                 .doOnError(ex -> log.error("LoanUpdated flow failed for loan {}", dto.getId(), ex)).subscribe();
     }
 

--- a/src/main/java/org/mifos/loanrisk/loan/handler/LoanWithdrawnHandler.java
+++ b/src/main/java/org/mifos/loanrisk/loan/handler/LoanWithdrawnHandler.java
@@ -11,6 +11,7 @@ import org.mifos.loanrisk.loan.common.LoanEventType;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -22,12 +23,14 @@ public class LoanWithdrawnHandler implements LoanMessageHandler {
     private final AggregatorService aggregatorService;
     private final LoanSnapshotRepository snapshotRepo;
     private final ObjectMapper mapper;
+    private final TransactionalOperator txOperator;
 
     @Override
     public void handle(JsonNode payload) throws JsonProcessingException {
         LoanAccountDataV1 dto = mapper.treeToValue(payload, LoanAccountDataV1.class);
         Mono.when(aggregatorService.onLoanWithdrawn(dto),
                 snapshotRepo.deleteByLoanId(dto.getId()).doOnSuccess(v -> log.info("Snapshot deleted loan={}", dto.getId())))
-                .doOnError(ex -> log.error("LoanWithdrawn flow failed for loan {}", dto.getId(), ex)).subscribe();
+                .as(txOperator::transactional).doOnError(ex -> log.error("LoanWithdrawn flow failed for loan {}", dto.getId(), ex))
+                .subscribe();
     }
 }

--- a/src/main/java/org/mifos/loanrisk/messaging/domain/EventMessage.java
+++ b/src/main/java/org/mifos/loanrisk/messaging/domain/EventMessage.java
@@ -41,9 +41,12 @@ public class EventMessage {
     @Column("business_date")
     private String businessDate;
 
+    @Column("is_processed")
+    private Boolean processed;
+
     /** Convenience constructor that omits the auto-generated ID. */
     public EventMessage(Long eventId, String type, String category, String schema, String tenantId, LocalDateTime createdAt, byte[] payload,
-            String businessDate) {
+            String businessDate, Boolean processed) {
 
         this.eventId = eventId;
         this.type = type;
@@ -53,5 +56,6 @@ public class EventMessage {
         this.createdAt = createdAt;
         this.payload = payload;
         this.businessDate = businessDate;
+        this.processed = processed;
     }
 }

--- a/src/main/java/org/mifos/loanrisk/messaging/event/KafkaMessageConsumerHandler.java
+++ b/src/main/java/org/mifos/loanrisk/messaging/event/KafkaMessageConsumerHandler.java
@@ -17,6 +17,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
 
 @Component
 @Slf4j
@@ -28,6 +30,9 @@ public class KafkaMessageConsumerHandler implements MessageHandler {
 
     @Autowired
     private EventMessageRepository repository;
+
+    @Autowired
+    private TransactionalOperator txOperator;
 
     private final EventMapper eventMapper;
 
@@ -42,21 +47,30 @@ public class KafkaMessageConsumerHandler implements MessageHandler {
         try {
             MessageV1 messagePayload = MessageV1.fromByteBuffer(wrapperBuf);
             log.info("Received Kafka event of Category = {}, Type = {}", messagePayload.getCategory(), messagePayload.getType());
-            saveMessage(messagePayload);
-            EventEnvelope env = eventMapper.toEnvelope(messagePayload);
-            dispatcher.dispatch(env);
+            saveAndProcess(messagePayload).as(txOperator::transactional).subscribe();
 
-        } catch (IOException | ReflectiveOperationException ex) {
+        } catch (IOException ex) {
             log.error("Unable to process Kafka message", ex);
         }
     }
 
-    private void saveMessage(MessageV1 messagePayload) {
-
+    private Mono<Void> saveAndProcess(MessageV1 messagePayload) {
         EventMessage message = eventMapper.toEntity(messagePayload);
+        return repository.findByEventId(message.getEventId()).switchIfEmpty(repository.save(message))
+                .flatMap(evt -> processEvent(evt, messagePayload));
+    }
 
-        repository.save(message).doOnSuccess(savedMessage -> log.info("Saved message with ID: {}", savedMessage.getId()))
-                .doOnError(error -> log.error("Error saving message", error)).subscribe();
+    private Mono<Void> processEvent(EventMessage evt, MessageV1 payload) {
+        try {
+            EventEnvelope env = eventMapper.toEnvelope(payload);
+            dispatcher.dispatch(env);
+            evt.setProcessed(true);
+            return repository.save(evt).then();
+        } catch (Exception ex) {
+            log.error("Unable to process Kafka message", ex);
+            evt.setProcessed(false);
+            return repository.save(evt).then();
+        }
     }
 
 }

--- a/src/main/java/org/mifos/loanrisk/messaging/event/UnprocessedEventRunner.java
+++ b/src/main/java/org/mifos/loanrisk/messaging/event/UnprocessedEventRunner.java
@@ -1,0 +1,40 @@
+package org.mifos.loanrisk.messaging.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mifos.loanrisk.common.EventMapper;
+import org.mifos.loanrisk.messaging.dispatcher.DomainEventDispatcher;
+import org.mifos.loanrisk.messaging.domain.EventMessage;
+import org.mifos.loanrisk.messaging.repository.EventMessageRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UnprocessedEventRunner implements ApplicationRunner {
+
+    private final EventMessageRepository repository;
+    private final EventMapper mapper;
+    private final DomainEventDispatcher dispatcher;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        repository.findByProcessedFalse().flatMap(this::process).onErrorContinue((ex, obj) -> log.error("Failed to reprocess event", ex))
+                .subscribe();
+    }
+
+    private Flux<EventMessage> process(EventMessage msg) {
+        try {
+            dispatcher.dispatch(mapper.toEnvelope(msg));
+            msg.setProcessed(true);
+            log.info("Successfully processed unprocessed event {}", msg.getEventId());
+        } catch (Exception e) {
+            log.error("Failed processing event {}", msg.getEventId(), e);
+            msg.setProcessed(false);
+        }
+        return repository.save(msg).flux();
+    }
+}

--- a/src/main/java/org/mifos/loanrisk/messaging/repository/EventMessageRepository.java
+++ b/src/main/java/org/mifos/loanrisk/messaging/repository/EventMessageRepository.java
@@ -3,8 +3,15 @@ package org.mifos.loanrisk.messaging.repository;
 import org.mifos.loanrisk.messaging.domain.EventMessage;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface EventMessageRepository extends R2dbcRepository<EventMessage, Long> {
 
     Flux<EventMessage> findByType(String eventType);
+
+    Mono<Boolean> existsByEventId(Long eventId);
+
+    Mono<EventMessage> findByEventId(Long eventId);
+
+    Flux<EventMessage> findByProcessedFalse();
 }

--- a/src/main/java/org/mifos/loanrisk/service/AggregatorService.java
+++ b/src/main/java/org/mifos/loanrisk/service/AggregatorService.java
@@ -88,8 +88,7 @@ public class AggregatorService {
         /* Fetch, mutate, save */
         return repo.findByLoanId(doc.getParentEntityId())
                 .switchIfEmpty(Mono.error(new IllegalStateException("No Aggregator row for loan " + doc.getParentEntityId())))
-                .flatMap(ag -> mutateAggregator(ag, dt, added, doc.getId())).flatMap(repo::save)
-                .doOnSuccess(ag -> log.info("Aggregator {} updated: {} {}", ag.getId(), dt, added ? "added" : "removed")).then();
+                .flatMap(ag -> mutateAggregator(ag, dt, added, doc.getId())).flatMap(repo::save).then();
     }
 
     private Mono<Aggregator> mutateAggregator(Aggregator ag, DocumentType dt, boolean added, Long docId) {
@@ -114,6 +113,7 @@ public class AggregatorService {
                     ag.documentArrived(dt, docId);
                 }
             }
+            log.info("Aggregator {} updated with new document {} of type {}", ag.getId(), docId, dt);
         } else {
             boolean isLatest = switch (dt) {
                 case BANK_STATEMENT -> ag.getBankStmtId() != null && ag.getBankStmtId().equals(docId);
@@ -122,6 +122,7 @@ public class AggregatorService {
             };
             if (isLatest) {
                 ag.documentDeleted(dt);
+                log.info("Aggregator {} removed document {} of type {}", ag.getId(), docId, dt);
             } else {
                 log.info("document is not the latest one uploaded");
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,24 @@ spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.Str
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.admin.auto-create=true
+
+# fineract
+#fineract:
+#base-url: https://fineract.example.com
+#username: api-user
+#password: s3cr3t
+#connect-timeout: 5s
+#read-timeout: 10s
+fineract.base-url=https://localhost:8443/fineract-provider/api/v1
+fineract.username=mifos
+fineract.password=password
+# Connect timeout and read timeout for Fineract API
+fineract.connect-timeout=5s
+fineract.read-timeout=10s
+fineract.tenant-id=default
+
+#logging
+logging.level.reactor.netty.http.client=DEBUG
+
+# Toggle: trust every certificate in DEV (env var overrides this)
+fineract.ssl.trust-all=${FINERACT_SSL_TRUST_ALL:false}

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -23,5 +23,6 @@
     <include file="parts/002-add-loan-snapshot.xml" relativeToChangelogFile="true"/>
     <include file="parts/003-add-aggregator-doc-ids.xml" relativeToChangelogFile="true"/>
     <include file="parts/004-add-event-message-processed.xml" relativeToChangelogFile="true"/>
+    <include file="parts/005-add-document-meta.xml" relativeToChangelogFile="true"/>
 <!--    <include file="parts/003-update-loan-snapshot.xml" relativeToChangelogFile="true"/>-->
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -22,5 +22,6 @@
     <include file="parts/001-add-aggregator.xml" relativeToChangelogFile="true"/>
     <include file="parts/002-add-loan-snapshot.xml" relativeToChangelogFile="true"/>
     <include file="parts/003-add-aggregator-doc-ids.xml" relativeToChangelogFile="true"/>
+    <include file="parts/004-add-event-message-processed.xml" relativeToChangelogFile="true"/>
 <!--    <include file="parts/003-update-loan-snapshot.xml" relativeToChangelogFile="true"/>-->
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/parts/004-add-event-message-processed.xml
+++ b/src/main/resources/db/changelog/parts/004-add-event-message-processed.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="004-add-event-message-processed" author="codex">
+        <addColumn tableName="event_message">
+            <column name="is_processed" type="BOOLEAN" defaultValueBoolean="false"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/parts/005-add-document-meta.xml
+++ b/src/main/resources/db/changelog/parts/005-add-document-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="005-add-document-meta" author="codex">
+        <createTable tableName="document_meta">
+            <column name="id" type="BIGSERIAL">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="loan_id" type="BIGINT"/>
+            <column name="document_id" type="BIGINT"/>
+            <column name="object_key" type="VARCHAR(255)"/>
+            <column name="mime_type" type="VARCHAR(100)"/>
+            <column name="status" type="VARCHAR(20)"/>
+            <column name="created_at" type="TIMESTAMP"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchServiceTest.java
+++ b/src/test/java/org/mifos/loanrisk/document/service/fetch/DocumentFetchServiceTest.java
@@ -1,0 +1,134 @@
+package org.mifos.loanrisk.document.service.fetch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mifos.loanrisk.document.domain.DocumentMeta;
+import org.mifos.loanrisk.document.domain.DocumentStatus;
+import org.mifos.loanrisk.document.repository.DocumentMetaRepository;
+import org.mifos.loanrisk.document.storage.ObjectStorageClient;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mockito;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class DocumentFetchServiceTest {
+
+    private ObjectStorageClient storage;
+    private DocumentMetaRepository repo;
+    private TransactionalOperator txOp;
+    private DocumentFetchService service;
+
+    private AtomicReference<ClientRequest> captured;
+
+    @BeforeEach
+    void setUp() {
+        storage = mock(ObjectStorageClient.class);
+        repo = mock(DocumentMetaRepository.class);
+        txOp = mock(TransactionalOperator.class);
+
+        // Let transactional(Mono) / transactional(Flux) just return the original publisher
+        when(txOp.transactional(Mockito.<Mono<?>>any())).then(AdditionalAnswers.returnsFirstArg());
+        when(txOp.transactional(Mockito.<Flux<?>>any())).then(AdditionalAnswers.returnsFirstArg());
+
+        when(storage.put(any(byte[].class), anyString())).thenReturn(Mono.empty());
+        when(repo.save(any(DocumentMeta.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+        captured = new AtomicReference<>();
+    }
+
+    @Test
+    void fetch_ok_storesBytes_and_savesMeta_and_wrapsInTransaction() {
+        // Arrange: a successful HTTP 200 with bytes and a content-type
+        byte[] body = new byte[] { 1, 2, 3 };
+        ExchangeFunction exchange = request -> {
+            captured.set(request);
+            return Mono.just(okResponse("image/png", body));
+        };
+        WebClient client = WebClient.builder().exchangeFunction(exchange).build();
+        service = new DocumentFetchService(client, storage, repo, txOp);
+
+        // Act + Assert
+        StepVerifier.create(service.fetch("loans", 1L, 10L)).assertNext(meta -> {
+            assertEquals(1L, meta.getLoanId());
+            assertEquals(10L, meta.getDocumentId());
+            assertEquals("loans-10", meta.getObjectKey());
+            assertEquals("image/png", meta.getMimeType());
+            assertEquals(DocumentStatus.NEW, meta.getStatus());
+            assertNotNull(meta.getCreatedAt());
+            assertTrue(meta.getCreatedAt().isBefore(LocalDateTime.now().plusSeconds(1)));
+        }).verifyComplete();
+
+        // Verify request path
+        assertEquals("/loans/1/documents/10/attachment", captured.get().url().getPath());
+
+        // Verify side effects
+        verify(storage).put(new byte[] { 1, 2, 3 }, "loans-10");
+        verify(repo).save(any(DocumentMeta.class));
+
+        // Verify transactional wrapping
+        verify(txOp, times(1)).transactional(Mockito.<Mono<?>>any());
+        verifyNoMoreInteractions(txOp);
+    }
+
+    @Test
+    void fetch_httpError_bubblesUp_and_nothingIsPersisted() {
+        // Arrange: simulate a 404
+        ExchangeFunction exchange = request -> {
+            captured.set(request);
+            return Mono.just(ClientResponse.create(HttpStatus.NOT_FOUND).build());
+        };
+        WebClient client = WebClient.builder().exchangeFunction(exchange).build();
+        service = new DocumentFetchService(client, storage, repo, txOp);
+
+        // Act + Assert
+        StepVerifier.create(service.fetch("loans", 1L, 10L)).expectError(WebClientResponseException.class).verify();
+
+        // Ensure no storage nor repo save happened
+        verify(storage, never()).put(any(), anyString());
+        verify(repo, never()).save(any());
+        verify(txOp, never()).transactional(Mockito.<Mono<?>>any());
+    }
+
+    @Test
+    void fetch_repoFails_errorPropagates() {
+        // Arrange
+        byte[] body = new byte[] { 9, 9, 9 };
+        ExchangeFunction exchange = request -> {
+            captured.set(request);
+            return Mono.just(okResponse("application/pdf", body));
+        };
+        WebClient client = WebClient.builder().exchangeFunction(exchange).build();
+        service = new DocumentFetchService(client, storage, repo, txOp);
+
+        when(repo.save(any(DocumentMeta.class))).thenReturn(Mono.error(new RuntimeException("DB down")));
+
+        // Act + Assert
+        StepVerifier.create(service.fetch("loans", 2L, 20L)).expectErrorMessage("DB down").verify();
+
+        verify(storage).put(body, "loans-20");
+        verify(repo).save(any(DocumentMeta.class));
+        verify(txOp, times(1)).transactional(Mockito.<Mono<?>>any());
+    }
+
+    private static ClientResponse okResponse(String contentType, byte[] bytes) {
+        DefaultDataBufferFactory f = new DefaultDataBufferFactory();
+        DataBuffer buffer = f.wrap(bytes);
+        return ClientResponse.create(HttpStatus.OK).header(HttpHeaders.CONTENT_TYPE, contentType).body(Flux.just(buffer)).build();
+    }
+}

--- a/src/test/java/org/mifos/loanrisk/loan/handler/LoanCreatedHandlerTest.java
+++ b/src/test/java/org/mifos/loanrisk/loan/handler/LoanCreatedHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mifos.loanrisk.domain.LoanSnapshot;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 class LoanCreatedHandlerTest {
@@ -19,6 +20,7 @@ class LoanCreatedHandlerTest {
     private AggregatorService service;
     private LoanSnapshotRepository snapshotRepo;
     private ObjectMapper mapper;
+    private TransactionalOperator txOp;
     private LoanCreatedHandler handler;
     private LoanAccountDataV1 loan;
 
@@ -29,7 +31,9 @@ class LoanCreatedHandlerTest {
         mapper = mock(ObjectMapper.class);
         loan = mock(LoanAccountDataV1.class);
         when(loan.getId()).thenReturn(1L);
-        handler = new LoanCreatedHandler(service, snapshotRepo, mapper);
+        txOp = mock(TransactionalOperator.class);
+        when(txOp.transactional((Mono<Object>) any())).thenAnswer(inv -> inv.getArgument(0));
+        handler = new LoanCreatedHandler(service, snapshotRepo, mapper, txOp);
     }
 
     @Test

--- a/src/test/java/org/mifos/loanrisk/loan/handler/LoanRejectedHandlerTest.java
+++ b/src/test/java/org/mifos/loanrisk/loan/handler/LoanRejectedHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 class LoanRejectedHandlerTest {
@@ -17,6 +18,7 @@ class LoanRejectedHandlerTest {
     private AggregatorService service;
     private LoanSnapshotRepository snapshotRepo;
     private ObjectMapper mapper;
+    private TransactionalOperator txOp;
     private LoanRejectedHandler handler;
     private LoanAccountDataV1 loan;
 
@@ -27,7 +29,9 @@ class LoanRejectedHandlerTest {
         mapper = mock(ObjectMapper.class);
         loan = mock(LoanAccountDataV1.class);
         when(loan.getId()).thenReturn(1L);
-        handler = new LoanRejectedHandler(service, snapshotRepo, mapper);
+        txOp = mock(TransactionalOperator.class);
+        when(txOp.transactional((Mono<Object>) any())).thenAnswer(inv -> inv.getArgument(0));
+        handler = new LoanRejectedHandler(service, snapshotRepo, mapper, txOp);
     }
 
     @Test

--- a/src/test/java/org/mifos/loanrisk/loan/handler/LoanUpdatedHandlerTest.java
+++ b/src/test/java/org/mifos/loanrisk/loan/handler/LoanUpdatedHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.mifos.loanrisk.domain.LoanSnapshot;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 class LoanUpdatedHandlerTest {
@@ -21,6 +22,7 @@ class LoanUpdatedHandlerTest {
     private AggregatorService service;
     private LoanSnapshotRepository snapshotRepo;
     private ObjectMapper mapper;
+    private TransactionalOperator txOp;
     private LoanUpdatedHandler handler;
     private LoanAccountDataV1 loan;
     private LoanSnapshot snapshot;
@@ -33,7 +35,9 @@ class LoanUpdatedHandlerTest {
         loan = mock(LoanAccountDataV1.class);
         when(loan.getId()).thenReturn(1L);
         snapshot = new LoanSnapshot(1L, "old", LocalDateTime.now().minusDays(1));
-        handler = new LoanUpdatedHandler(service, snapshotRepo, mapper);
+        txOp = mock(TransactionalOperator.class);
+        when(txOp.transactional((Mono<Object>) any())).thenAnswer(inv -> inv.getArgument(0));
+        handler = new LoanUpdatedHandler(service, snapshotRepo, mapper, txOp);
     }
 
     @Test

--- a/src/test/java/org/mifos/loanrisk/loan/handler/LoanWithdrawnHandlerTest.java
+++ b/src/test/java/org/mifos/loanrisk/loan/handler/LoanWithdrawnHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mifos.loanrisk.repository.LoanSnapshotRepository;
 import org.mifos.loanrisk.service.AggregatorService;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 class LoanWithdrawnHandlerTest {
@@ -17,6 +18,7 @@ class LoanWithdrawnHandlerTest {
     private AggregatorService service;
     private LoanSnapshotRepository snapshotRepo;
     private ObjectMapper mapper;
+    private TransactionalOperator txOp;
     private LoanWithdrawnHandler handler;
     private LoanAccountDataV1 loan;
 
@@ -27,7 +29,9 @@ class LoanWithdrawnHandlerTest {
         mapper = mock(ObjectMapper.class);
         loan = mock(LoanAccountDataV1.class);
         when(loan.getId()).thenReturn(1L);
-        handler = new LoanWithdrawnHandler(service, snapshotRepo, mapper);
+        txOp = mock(TransactionalOperator.class);
+        when(txOp.transactional((Mono<Object>) any())).thenAnswer(inv -> inv.getArgument(0));
+        handler = new LoanWithdrawnHandler(service, snapshotRepo, mapper, txOp);
     }
 
     @Test

--- a/src/test/java/org/mifos/loanrisk/service/AggregatorServiceTest.java
+++ b/src/test/java/org/mifos/loanrisk/service/AggregatorServiceTest.java
@@ -35,12 +35,10 @@ class AggregatorServiceTest {
         when(repo.existsByLoanId(1L)).thenReturn(Mono.just(false));
         when(repo.save(any())).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
 
-        StepVerifier.create(service.onLoanCreated(loan))
-                .assertNext(ag -> {
-                    assertEquals(1L, ag.getLoanId());
-                    assertEquals(ServiceStatus.PENDING, ag.getAssessmentStatus());
-                })
-                .verifyComplete();
+        StepVerifier.create(service.onLoanCreated(loan)).assertNext(ag -> {
+            assertEquals(1L, ag.getLoanId());
+            assertEquals(ServiceStatus.PENDING, ag.getAssessmentStatus());
+        }).verifyComplete();
 
         verify(repo).save(any(Aggregator.class));
     }


### PR DESCRIPTION
### 1) WebClient & Config to Talk to Fineract
- `WebClientConfig` with `FineractProps` (base URL, tenant, auth, timeouts, SSL trust-all for dev).
- Uses Reactor Netty client with configurable connect/read timeouts.

### 2) Document Domain & Persistence
- **`DocumentMeta`** entity + **`DocumentStatus`** enum.
- **`DocumentMetaRepository`** (reactive/R2DBC).
- Captures `loanId/entityId`, `documentId`, `objectKey`, `mimeType`, `status`, `createdAt`.

### 3) Fetch & Store Pipeline
- **`DocumentFetchService`**:
  - Builds Fineract URL: `/<entityType>/<entityId>/documents/<documentId>/attachment`.
  - Downloads bytes with `WebClient`.
  - Persists bytes using **`ObjectStorageClient`** (with a `LocalObjectStorageClient` implementation).
  - Saves `DocumentMeta` in DB.
  - Wraps the save in a **reactive transaction** (`TransactionalOperator`).

### 4) Event Hook
- **`DocumentCreatedHandler`** listens to *document created* external events and invokes `DocumentFetchService.fetch(...)`.

### 5) DB Changelog
- **Liquibase file `005-add-document-meta.xml`** introduces the `document_meta` table.

### 6) Tests
- **`DocumentFetchServiceTest`**:
  - Mocks `ObjectStorageClient`, `DocumentMetaRepository`, and `TransactionalOperator`.
  - Stubs `WebClient` using a custom `ExchangeFunction`.
  - Verifies:
    - Correct request path,
    - Bytes saved to storage,
    - Metadata persisted,
    - Transaction operator wrapping,
    - Proper error propagation on HTTP/DB failures.