### PR TITLE
Added bank statement analysis support

### DIFF
--- a/src/main/java/org/mifos/loanrisk/document/handler/DocumentCreatedHandler.java
+++ b/src/main/java/org/mifos/loanrisk/document/handler/DocumentCreatedHandler.java
@@ -8,8 +8,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.avro.document.v1.DocumentDataV1;
 import org.mifos.loanrisk.document.common.DocumentEventType;
 import org.mifos.loanrisk.document.common.Handles;
-import org.mifos.loanrisk.document.service.fetch.DocumentFetchService;
+import org.mifos.loanrisk.common.LoanStatus;
+import org.mifos.loanrisk.common.ServiceStatus;
 import org.mifos.loanrisk.service.AggregatorService;
+import org.mifos.loanrisk.external.bsa.BankStatementAnalysisService;
+import org.mifos.loanrisk.external.bsa.BankStatementAnalysisServiceFactory;
+import reactor.core.publisher.Mono;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,16 +23,37 @@ import org.springframework.stereotype.Component;
 public class DocumentCreatedHandler implements DocumentMessageHandler {
 
     private final AggregatorService aggregatorService;
-    private final DocumentFetchService documentFetchService;
+    private final BankStatementAnalysisServiceFactory bsaFactory;
     private final ObjectMapper mapper;
 
     @Override
     public void handle(JsonNode payload) throws JsonProcessingException {
         DocumentDataV1 documentData = mapper.treeToValue(payload, DocumentDataV1.class);
-        aggregatorService
-                .onDocumentCreated(documentData).then(documentFetchService.fetch(documentData.getParentEntityType(),
-                        documentData.getParentEntityId(), documentData.getId()))
+        aggregatorService.onDocumentCreated(documentData)
+                .then(initiateExternalServices(documentData))
                 .doOnError(ex -> log.error("DocumentCreated flow failed", ex)).subscribe();
 
+    }
+
+    /**
+     * After the generic document processing is complete, determine which
+     * external services can now be triggered and initiate them.
+     */
+    private Mono<Void> initiateExternalServices(DocumentDataV1 documentData) {
+        if (!"loans".equalsIgnoreCase(documentData.getParentEntityType())) {
+            return Mono.empty();
+        }
+
+        return aggregatorService.getByLoanId(documentData.getParentEntityId())
+                .flatMap(ag -> {
+                    // Bank statement analysis requirements
+                    if (ag.getLoanStatus() == LoanStatus.SUBMITTED_AND_PENDING_APPROVAL
+                            && Boolean.TRUE.equals(ag.getBankStmtUploaded())
+                            && ag.getBankStmtStatus() == ServiceStatus.PENDING) {
+                        BankStatementAnalysisService svc = bsaFactory.getService();
+                        return svc.analyze(documentData, ag);
+                    }
+                    return Mono.empty();
+                });
     }
 }

--- a/src/main/java/org/mifos/loanrisk/domain/Aggregator.java
+++ b/src/main/java/org/mifos/loanrisk/domain/Aggregator.java
@@ -155,7 +155,6 @@ public class Aggregator {
         this.tenantId = loan.getClientExternalId();
         this.loanStatus = LoanStatus.fromInt(loan.getStatus().getId());
         this.lastUpdated = LocalDateTime.now();
-        reevaluateStatus(); // recompute PENDING status
     }
 
     public void documentArrived(DocumentType dt, Long documentId) {

--- a/src/main/java/org/mifos/loanrisk/external/bsa/BankStatementAnalysisService.java
+++ b/src/main/java/org/mifos/loanrisk/external/bsa/BankStatementAnalysisService.java
@@ -1,0 +1,25 @@
+package org.mifos.loanrisk.external.bsa;
+
+import org.apache.fineract.avro.document.v1.DocumentDataV1;
+import org.mifos.loanrisk.domain.Aggregator;
+import reactor.core.publisher.Mono;
+
+/**
+ * Strategy interface for bank statement analysis providers. Implementations
+ * encapsulate the details of talking to a particular third party API.
+ */
+public interface BankStatementAnalysisService {
+
+    /**
+     * @return unique provider name (e.g. "arya").
+     */
+    String getName();
+
+    /**
+     * Initiates analysis of the supplied bank statement document. The
+     * Aggregator instance is provided so that implementations can update
+     * service status or store metadata as needed.
+     */
+    Mono<Void> analyze(DocumentDataV1 document, Aggregator aggregator);
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/bsa/BankStatementAnalysisServiceFactory.java
+++ b/src/main/java/org/mifos/loanrisk/external/bsa/BankStatementAnalysisServiceFactory.java
@@ -1,0 +1,34 @@
+package org.mifos.loanrisk.external.bsa;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Factory that selects a {@link BankStatementAnalysisService} implementation
+ * based on application configuration.
+ */
+@Component
+@RequiredArgsConstructor
+public class BankStatementAnalysisServiceFactory {
+
+    private final List<BankStatementAnalysisService> services;
+
+    /**
+     * Name of the provider to use. Defaults to "arya" if not specified.
+     */
+    @Value("${bsa.provider:arya}")
+    private String provider;
+
+    /**
+     * @return the service implementation matching the configured provider
+     *         name.
+     * @throws IllegalStateException if no matching provider is available
+     */
+    public BankStatementAnalysisService getService() {
+        return services.stream().filter(s -> s.getName().equalsIgnoreCase(provider)).findFirst()
+                .orElseThrow(() -> new IllegalStateException("No BankStatementAnalysisService for provider " + provider));
+    }
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/bsa/arya/AryaBankStatementAnalysisService.java
+++ b/src/main/java/org/mifos/loanrisk/external/bsa/arya/AryaBankStatementAnalysisService.java
@@ -1,0 +1,77 @@
+package org.mifos.loanrisk.external.bsa.arya;
+
+import java.util.Base64;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.avro.document.v1.DocumentDataV1;
+import org.mifos.loanrisk.common.ServiceStatus;
+import org.mifos.loanrisk.domain.Aggregator;
+import org.mifos.loanrisk.document.domain.DocumentMeta;
+import org.mifos.loanrisk.document.service.fetch.DocumentFetchService;
+import org.mifos.loanrisk.document.storage.ObjectStorageClient;
+import org.mifos.loanrisk.external.bsa.BankStatementAnalysisService;
+import org.mifos.loanrisk.external.bsa.event.BsaRequestedEvent;
+import org.mifos.loanrisk.repository.AggregatorRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * Bank statement analysis implementation using Arya's API.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AryaBankStatementAnalysisService implements BankStatementAnalysisService {
+
+    private final DocumentFetchService documentFetchService;
+    private final ObjectStorageClient storageClient;
+    private final AggregatorRepository aggregatorRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${bsa.arya.base-url:https://ping.arya.ai/api/v1}")
+    private String baseUrl;
+
+    @Value("${bsa.arya.token:}")
+    private String token;
+
+    @Override
+    public String getName() {
+        return "arya";
+    }
+
+    @Override
+    public Mono<Void> analyze(DocumentDataV1 document, Aggregator aggregator) {
+        return documentFetchService.fetch(document.getParentEntityType(), document.getParentEntityId(), document.getId())
+                .flatMap((DocumentMeta meta) -> storageClient.get(meta.getObjectKey()))
+                .map(bytes -> Base64.getEncoder().encodeToString(bytes))
+                .flatMap(base64 -> sendRequest(base64, document, aggregator));
+    }
+
+    private Mono<Void> sendRequest(String base64, DocumentDataV1 document, Aggregator aggregator) {
+        String reqId = UUID.randomUUID().toString();
+        AryaBsaRequest body = new AryaBsaRequest("pdf", reqId, "pdf", base64);
+        WebClient client = webClientBuilder.baseUrl(baseUrl).build();
+        return client.post().uri("/bank-statement-analyser")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("token", token)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(AryaBsaResponse.class)
+                .doOnNext(resp -> eventPublisher
+                        .publishEvent(new BsaRequestedEvent(this, aggregator.getLoanId(), document.getId(), reqId)))
+                .doOnError(err -> log.error("Arya BSA request failed", err))
+                .then(updateAggregatorStatus(aggregator));
+    }
+
+    private Mono<Void> updateAggregatorStatus(Aggregator aggregator) {
+        aggregator.setBankStmtStatus(ServiceStatus.REQUESTED);
+        return aggregatorRepository.save(aggregator).then();
+    }
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/bsa/arya/AryaBsaRequest.java
+++ b/src/main/java/org/mifos/loanrisk/external/bsa/arya/AryaBsaRequest.java
@@ -1,0 +1,14 @@
+package org.mifos.loanrisk.external.bsa.arya;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO for Arya's bank statement analysis request body.
+ */
+public record AryaBsaRequest(
+        @JsonProperty("doc_type") String docType,
+        @JsonProperty("req_id") String reqId,
+        @JsonProperty("report_type") String reportType,
+        @JsonProperty("doc_base64") String docBase64) {
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/bsa/arya/AryaBsaResponse.java
+++ b/src/main/java/org/mifos/loanrisk/external/bsa/arya/AryaBsaResponse.java
@@ -1,0 +1,15 @@
+package org.mifos.loanrisk.external.bsa.arya;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/**
+ * DTO for Arya's bank statement analysis response.
+ */
+public record AryaBsaResponse(
+        @JsonProperty("req_id") String reqId,
+        @JsonProperty("success") Boolean success,
+        @JsonProperty("error_message") String errorMessage,
+        @JsonProperty("data") Map<String, Object> data) {
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/bsa/event/BsaRequestedEvent.java
+++ b/src/main/java/org/mifos/loanrisk/external/bsa/event/BsaRequestedEvent.java
@@ -1,0 +1,34 @@
+package org.mifos.loanrisk.external.bsa.event;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Spring application event published after a bank statement analysis request
+ * has been sent to an external provider.
+ */
+public class BsaRequestedEvent extends ApplicationEvent {
+
+    private final Long loanId;
+    private final Long documentId;
+    private final String requestId;
+
+    public BsaRequestedEvent(Object source, Long loanId, Long documentId, String requestId) {
+        super(source);
+        this.loanId = loanId;
+        this.documentId = documentId;
+        this.requestId = requestId;
+    }
+
+    public Long getLoanId() {
+        return loanId;
+    }
+
+    public Long getDocumentId() {
+        return documentId;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/credit/CreditBureauService.java
+++ b/src/main/java/org/mifos/loanrisk/external/credit/CreditBureauService.java
@@ -1,0 +1,23 @@
+package org.mifos.loanrisk.external.credit;
+
+import org.mifos.loanrisk.domain.Aggregator;
+import reactor.core.publisher.Mono;
+
+/**
+ * Interface for pulling credit bureau reports from third party providers.
+ * Concrete implementations should encapsulate provider specific details
+ * and be registered as Spring beans so they can be selected at runtime.
+ */
+public interface CreditBureauService {
+
+    /**
+     * @return unique provider name.
+     */
+    String getName();
+
+    /**
+     * Initiates a credit bureau pull for the given loan/aggregator.
+     */
+    Mono<Void> pullReport(Aggregator aggregator);
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/credit/CreditBureauServiceFactory.java
+++ b/src/main/java/org/mifos/loanrisk/external/credit/CreditBureauServiceFactory.java
@@ -1,0 +1,26 @@
+package org.mifos.loanrisk.external.credit;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Factory for selecting a {@link CreditBureauService} implementation at
+ * runtime. Currently only placeholder services may exist.
+ */
+@Component
+@RequiredArgsConstructor
+public class CreditBureauServiceFactory {
+
+    private final List<CreditBureauService> services;
+
+    @Value("${credit.provider:}")
+    private String provider;
+
+    public CreditBureauService getService() {
+        return services.stream().filter(s -> s.getName().equalsIgnoreCase(provider)).findFirst()
+                .orElseThrow(() -> new IllegalStateException("No CreditBureauService for provider " + provider));
+    }
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/ekyc/EkycVerificationService.java
+++ b/src/main/java/org/mifos/loanrisk/external/ekyc/EkycVerificationService.java
@@ -1,0 +1,19 @@
+package org.mifos.loanrisk.external.ekyc;
+
+import org.apache.fineract.avro.document.v1.DocumentDataV1;
+import org.mifos.loanrisk.domain.Aggregator;
+import reactor.core.publisher.Mono;
+
+/**
+ * Interface for electronic KYC verification providers.
+ */
+public interface EkycVerificationService {
+
+    String getName();
+
+    /**
+     * Initiates an eKYC verification for the supplied document/loan.
+     */
+    Mono<Void> verify(DocumentDataV1 document, Aggregator aggregator);
+}
+

--- a/src/main/java/org/mifos/loanrisk/external/ekyc/EkycVerificationServiceFactory.java
+++ b/src/main/java/org/mifos/loanrisk/external/ekyc/EkycVerificationServiceFactory.java
@@ -1,0 +1,22 @@
+package org.mifos.loanrisk.external.ekyc;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EkycVerificationServiceFactory {
+
+    private final List<EkycVerificationService> services;
+
+    @Value("${ekyc.provider:}")
+    private String provider;
+
+    public EkycVerificationService getService() {
+        return services.stream().filter(s -> s.getName().equalsIgnoreCase(provider)).findFirst()
+                .orElseThrow(() -> new IllegalStateException("No EkycVerificationService for provider " + provider));
+    }
+}
+

--- a/src/main/java/org/mifos/loanrisk/service/AggregatorService.java
+++ b/src/main/java/org/mifos/loanrisk/service/AggregatorService.java
@@ -30,6 +30,10 @@ public class AggregatorService {
         });
     }
 
+    public Mono<Aggregator> getByLoanId(Long loanId) {
+        return repo.findByLoanId(loanId);
+    }
+
     public Mono<Void> onLoanUpdated(LoanAccountDataV1 loan) {
         return repo.findByLoanId(loan.getId())
                 .switchIfEmpty(Mono.error(new IllegalStateException("No Aggregator row for loan " + loan.getId()))).flatMap(ag -> {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,3 +40,11 @@ logging.level.reactor.netty.http.client=DEBUG
 
 # Toggle: trust every certificate in DEV (env var overrides this)
 fineract.ssl.trust-all=${FINERACT_SSL_TRUST_ALL:false}
+
+# External risk service configuration
+# Which provider implementation to use for bank statement analysis
+bsa.provider=arya
+# Base URL for Arya's bank statement analysis API
+bsa.arya.base-url=https://ping.arya.ai/api/v1
+# Token is expected via environment variable or external configuration:
+bsa.arya.token=<secret>


### PR DESCRIPTION
- Removed the in-entity external service requirement check in Aggregator.updateFromLoan, deferring those checks to event handlers for a cleaner, decoupled design
- Added a post-processing hook in DocumentCreatedHandler to trigger external services (e.g., bank statement analysis) once prerequisites are met
- Introduced a flexible strategy/factory framework with an Arya-backed bank statement analysis implementation, enabling secure token-based API calls and event publication
- Added external-service configuration entries to application.properties, keeping provider choice and token handling outside of source control

Jira: [MX-26](https://mifosforge.jira.com/browse/MX-26)


[MX-26]: https://mifosforge.jira.com/browse/MX-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ