### PR TITLE
GAZ-318: Fix Dockerfile runtime base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN ./gradlew clean bootJar -x test --no-daemon
 # ────────────────────────────────
 # Stage 2  — Runtime image
 # ────────────────────────────────
-FROM openjdk:21-jdk-slim
+FROM azul/zulu-openjdk-alpine:21-jre-headless
 WORKDIR /opt/app
 
-# non-root user for better security
-RUN useradd -ms /bin/bash loanuser
+# non-root user for better security (Alpine/busybox: adduser, not useradd)
+RUN adduser -D -s /bin/sh loanuser
 USER loanuser
 
 COPY --from=builder /app/build/libs/*.jar app.jar


### PR DESCRIPTION
**Summary**


The runtime stage's base image `openjdk:21-jdk-slim` no longer exists on Docker Hub; the official `openjdk` images were deprecated and removed, so `docker build` fails to resolve it. Switch to `azul/zulu-openjdk-alpine:21-jre-headless`: a certified OpenJDK build (Azul Zulu), and the Alpine variant is much smaller than an Ubuntu-based JRE, better for the Raspberry Pi / memory-constrained targets. Alpine ships busybox, so the runtime user is created with `adduser` instead of `useradd` (and `/bin/sh` in place of `/bin/bash`).


**Testing**

Built the image with this fix (multi-stage build succeeds, `fineract-avro-schemas` resolves) and verified it on-cluster: it runs Zulu 21.0.11, boots, subscribes to Kafka, and consumes Fineract 1.14 external-events end-to-end. A loan created in Fineract flows through Kafka, and the module stores the loan snapshot + assessment record.
